### PR TITLE
fix: run the trailingComma RFC reader law against every engine

### DIFF
--- a/laws/shared/src/main/scala/kantan/csv/laws/RfcReaderLaws.scala
+++ b/laws/shared/src/main/scala/kantan/csv/laws/RfcReaderLaws.scala
@@ -61,8 +61,12 @@ trait RfcReaderLaws {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ListAppend"))
-  def trailingComma(csv: List[List[Cell]]): Boolean =
-    equals(cellsToCsv(csv, ",", ",\r\n"), csv.map(_ :+ Cell.Empty))
+  def trailingComma(csv: List[List[Cell]]): Boolean = {
+    // Every row is terminated by a trailing comma followed by CRLF, so every row is expected to gain a trailing empty
+    // cell. `mkString(sep)` only interleaves the separator, so we append it explicitly to every row.
+    val encoded = csv.map(_.map(_.encoded).mkString(",") + ",\r\n").mkString
+    equals(encoded, csv.map(_ :+ Cell.Empty))
+  }
 
   // - RFC 4180: 2.5 ---------------------------------------------------------------------------------------------------
   // -------------------------------------------------------------------------------------------------------------------

--- a/laws/shared/src/main/scala/kantan/csv/laws/discipline/RfcReaderTests.scala
+++ b/laws/shared/src/main/scala/kantan/csv/laws/discipline/RfcReaderTests.scala
@@ -34,7 +34,7 @@ trait RfcReaderTests extends Laws {
       "empty ending" -> forAll(laws.emptyEnding),
       "leading whitespace" -> forAll(laws.leadingWhitespace),
       "trailing whitespace" -> forAll(laws.trailingWhitespace),
-      "trailing comma" -> forAll(laws.trailingWhitespace),
+      "trailing comma" -> forAll(laws.trailingComma),
       "unnecessary double quotes" -> forAll(laws.unnecessaryDoubleQuotes),
       "unescaped double quotes" -> forAll(laws.unescapedDoubleQuotes),
       "escaped content" -> forAll(laws.escapedCells)


### PR DESCRIPTION
## Summary

- `laws.trailingComma` was never exercised. `RfcReaderTests.scala:37` labelled a rule "trailing comma" but passed `laws.trailingWhitespace` — a copy-paste of the row above. So the trailing-comma case (`1,2,\r\n` → `[1, 2, ""]`) was untested against all three engines.
- Fixing that wiring revealed the law itself was broken. It used `cellsToCsv(csv, ",", ",\r\n")`, whose `mkString(",\r\n")` only interleaves rows — the last row never received a trailing comma, so a single-row input like `List(List(Escaped("\"")))` produced CSV `""""` (no trailing comma) but `csv.map(_ :+ Cell.Empty)` still expected a trailing empty cell. Multi-row inputs were equally broken on the last row.
- `trailingComma` now appends `",\r\n"` after every row, so every row gets the trailing empty cell the law promises. All three engines (Internal, Jackson, Commons) pass.

## Test plan

- [x] `coreJVM2_13/testOnly kantan.csv.engine.InternalReaderTests` — 41/41 green
- [x] `jacksonJVM2_13/testOnly kantan.csv.engine.jackson.JacksonReaderTests` — 41/41 green
- [x] `commonsJVM2_13/testOnly kantan.csv.engine.commons.CommonsReaderTests` — 41/41 green
- [x] `scalafmtAll`