### PR TITLE
fix: escape embedded quote characters under QuotePolicy.Always

### DIFF
--- a/core/shared/src/main/scala/kantan/csv/engine/InternalWriter.scala
+++ b/core/shared/src/main/scala/kantan/csv/engine/InternalWriter.scala
@@ -43,7 +43,8 @@ private[csv] class InternalWriter(out: Writer, val conf: CsvConfiguration) exten
         else escapeIndex(index + 1)
       }
 
-    // If we're configured to always quote, do so. Embedded quote characters must still be doubled per RFC 4180 §2.7.
+    // If we're configured to always quote, do so. Embedded quote characters must still be doubled per RFC 4180 §2
+    // rule 7 — see https://datatracker.ietf.org/doc/html/rfc4180#section-2.
     if(conf.quotePolicy == CsvConfiguration.QuotePolicy.Always) {
       out.write(conf.quote.toInt)
       escape(0, 0)

--- a/core/shared/src/main/scala/kantan/csv/engine/InternalWriter.scala
+++ b/core/shared/src/main/scala/kantan/csv/engine/InternalWriter.scala
@@ -43,10 +43,10 @@ private[csv] class InternalWriter(out: Writer, val conf: CsvConfiguration) exten
         else escapeIndex(index + 1)
       }
 
-    // If we're configured to always quote, do so.
+    // If we're configured to always quote, do so. Embedded quote characters must still be doubled per RFC 4180 §2.7.
     if(conf.quotePolicy == CsvConfiguration.QuotePolicy.Always) {
       out.write(conf.quote.toInt)
-      out.write(str)
+      escape(0, 0)
       out.write(conf.quote.toInt)
     }
 

--- a/core/shared/src/test/scala/kantan/csv/engine/InternalWriterTests.scala
+++ b/core/shared/src/test/scala/kantan/csv/engine/InternalWriterTests.scala
@@ -18,7 +18,22 @@ package kantan.csv.engine
 
 import kantan.csv.laws.discipline.DisciplineSuite
 import kantan.csv.laws.discipline.WriterEngineTests
+import kantan.csv.ops.*
+import kantan.csv.rfc
 
 class InternalWriterTests extends DisciplineSuite {
   checkAll("InternalWriter", WriterEngineTests(WriterEngine.internalCsvWriterEngine).writerEngine)
+
+  test("cells containing the quote char must be escaped under QuotePolicy.Always") {
+    List(List("a\"b")).asCsv(rfc.quoteAll) should be("\"a\"\"b\"\r\n")
+  }
+
+  test("cells containing multiple quote chars must be escaped under QuotePolicy.Always") {
+    List(List("\"hello\"")).asCsv(rfc.quoteAll) should be("\"\"\"hello\"\"\"\r\n")
+  }
+
+  test("cells containing the quote char round-trip under QuotePolicy.Always") {
+    val rows = List(List("a\"b", "plain", "c\"\"d"))
+    rows.asCsv(rfc.quoteAll).unsafeReadCsv[List, List[String]](rfc) should be(rows)
+  }
 }


### PR DESCRIPTION
## Summary

- `InternalWriter.safeWrite` wrote the cell contents verbatim between the surrounding quotes when `QuotePolicy.Always` was active. A cell `a"b` came out as `"a"b"` — three tokens to any RFC-compliant reader — instead of `"a""b"`.
- [RFC 4180 §2 rule 7](https://datatracker.ietf.org/doc/html/rfc4180#section-2) requires embedded quote characters to be doubled regardless of whether the surrounding quoting was strictly necessary:
  > If double-quotes are used to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another double quote.

  The `WhenNeeded` branch already did this via the tailrec `escape` helper; the `Always` branch now reuses the same helper.
- Three regression tests added (single embedded quote, cell composed entirely of quotes, multi-cell round-trip).

## Test plan

- [x] `coreJVM2_13/testOnly kantan.csv.engine.InternalWriterTests` — 8/8 green (5 existing + 3 new)
- [x] `coreJVM3/testOnly kantan.csv.engine.InternalWriterTests` — 8/8 green
- [x] `scalafmtAll`

## Repro without the fix

```scala
import kantan.csv._, kantan.csv.ops._
List(List("a\"b")).asCsv(rfc.quoteAll)
// before: "\"a\"b\"\r\n"   (malformed CSV)
// after:  "\"a\"\"b\"\r\n" (RFC-compliant)
```