### PR TITLE
fix: trim input in javaEnumStringCodec for consistency with sibling codecs

### DIFF
--- a/codecs/core/jvm/src/main/scala/kantan/codecs/strings/PlatformSpecificInstances.scala
+++ b/codecs/core/jvm/src/main/scala/kantan/codecs/strings/PlatformSpecificInstances.scala
@@ -47,7 +47,7 @@ trait PlatformSpecificInstances {
   implicit def javaEnumStringCodec[T <: Enum[T]](implicit tag: ClassTag[T]): StringCodec[T] =
     StringCodec.from(StringDecoder.makeSafe("Enum") { s =>
       val enumClass = tag.runtimeClass.asInstanceOf[Class[T]]
-      Enum.valueOf(enumClass, s)
+      Enum.valueOf(enumClass, s.trim)
     })(_.name())
 
   /** Defines a [[StringCodec]] instance for `java.net.URL`.

--- a/codecs/core/jvm/src/test/scala/kantan/codecs/strings/AccessModeCodecTests.scala
+++ b/codecs/core/jvm/src/test/scala/kantan/codecs/strings/AccessModeCodecTests.scala
@@ -37,4 +37,9 @@ class AccessModeCodecTests extends DisciplineSuite {
   )
   checkAll("TaggedEncoder[AccessMode]", EncoderTests[String, AccessMode, tagged.type].encoder[Int, Int])
 
+  test("StringDecoder[Enum] should trim leading and trailing whitespace like every other codec") {
+    StringDecoder[AccessMode].decode(" READ\t") should be(Right(AccessMode.READ))
+    StringDecoder[AccessMode].decode("\nWRITE ") should be(Right(AccessMode.WRITE))
+  }
+
 }

--- a/codecs/core/jvm/src/test/scala/kantan/codecs/strings/AccessModeCodecTests.scala
+++ b/codecs/core/jvm/src/test/scala/kantan/codecs/strings/AccessModeCodecTests.scala
@@ -37,7 +37,7 @@ class AccessModeCodecTests extends DisciplineSuite {
   )
   checkAll("TaggedEncoder[AccessMode]", EncoderTests[String, AccessMode, tagged.type].encoder[Int, Int])
 
-  test("StringDecoder[Enum] should trim leading and trailing whitespace like every other codec") {
+  test("StringDecoder[Enum] should trim leading and trailing whitespace like other string-parsing codecs") {
     StringDecoder[AccessMode].decode(" READ\t") should be(Right(AccessMode.READ))
     StringDecoder[AccessMode].decode("\nWRITE ") should be(Right(AccessMode.WRITE))
   }


### PR DESCRIPTION
## Summary

- `javaEnumStringCodec` was the only `StringCodec` in `PlatformSpecificInstances` that didn't call `.trim` before parsing. `URL`, `URI`, `File`, `Path`, and every numeric/boolean codec in `codecs/strings/codecs.scala` do.
- Result: a CSV field `"READ "` (trailing space) decoded fine as an `Int` column but failed as a `java.nio.file.AccessMode` column — a silent asymmetry that surfaces as hard-to-diagnose user bugs when whitespace creeps into mixed-type rows.
- Added `.trim` to match sibling behaviour; regression test in `AccessModeCodecTests`.

## Test plan

- [x] `codecs-coreJVM2_13/testOnly kantan.codecs.strings.AccessModeCodecTests` — 55/55 green
- [x] `codecs-coreJVM3/testOnly kantan.codecs.strings.AccessModeCodecTests` — 55/55 green
- [x] `scalafmtAll`