### PR TITLE
fix: close underlying resources on error paths in core read/write ops

### DIFF
--- a/core/shared/src/main/scala/kantan/csv/CsvReader.scala
+++ b/core/shared/src/main/scala/kantan/csv/CsvReader.scala
@@ -27,22 +27,20 @@ object CsvReader {
   def apply[A: HeaderDecoder](reader: Reader, conf: CsvConfiguration)(implicit
     e: ReaderEngine
   ): CsvReader[ReadResult[A]] = {
-    val data: CsvReader[ReadResult[Seq[String]]] = e.readerFor(reader, conf)
+    val rows: CsvReader[ReadResult[Seq[String]]] = e.readerFor(reader, conf)
 
     val decoder =
-      if(conf.hasHeader && data.hasNext)
-        data.next().flatMap(header => HeaderDecoder[A].fromHeader(header.map(_.trim())))
+      if(conf.hasHeader && rows.hasNext)
+        rows.next().flatMap(header => HeaderDecoder[A].fromHeader(header.map(_.trim())))
       else Right(HeaderDecoder[A].noHeader)
 
-    decoder
-      .map(d => data.map(_.flatMap(d.decode)))
-      .left
-      .map { error =>
-        // Header decoding failed, so the returned iterator will not reference `data`. Release it eagerly so the
+    decoder match {
+      case Right(d) => rows.map(_.flatMap(d.decode))
+      case Left(error) =>
+        // Header decoding failed, so the returned iterator will not reference `rows`. Release it eagerly so the
         // underlying Reader doesn't leak.
-        data.close()
+        rows.close()
         ResourceIterator(ReadResult.failure(error))
-      }
-      .merge
+    }
   }
 }

--- a/core/shared/src/main/scala/kantan/csv/CsvReader.scala
+++ b/core/shared/src/main/scala/kantan/csv/CsvReader.scala
@@ -37,7 +37,12 @@ object CsvReader {
     decoder
       .map(d => data.map(_.flatMap(d.decode)))
       .left
-      .map(error => ResourceIterator(ReadResult.failure(error)))
+      .map { error =>
+        // Header decoding failed, so the returned iterator will not reference `data`. Release it eagerly so the
+        // underlying Reader doesn't leak.
+        data.close()
+        ResourceIterator(ReadResult.failure(error))
+      }
       .merge
   }
 }

--- a/core/shared/src/main/scala/kantan/csv/CsvSink.scala
+++ b/core/shared/src/main/scala/kantan/csv/CsvSink.scala
@@ -19,6 +19,7 @@ package kantan.csv
 import java.io.Writer
 import kantan.codecs.resource.WriterResource
 import kantan.csv.engine.WriterEngine
+import scala.util.Using
 
 /** Type class for all types that can be turned into [[CsvWriter]] instances.
   *
@@ -41,13 +42,11 @@ trait CsvSink[-S] extends Serializable { self =>
     * @param conf
     *   CSV writing behaviour.
     */
-  def write[A: HeaderEncoder](s: S, rows: IterableOnce[A], conf: CsvConfiguration)(implicit e: WriterEngine): Unit = {
-    val w = writer(s, conf)
-    try {
+  def write[A: HeaderEncoder](s: S, rows: IterableOnce[A], conf: CsvConfiguration)(implicit e: WriterEngine): Unit =
+    Using.resource(writer(s, conf)) { w =>
       w.write(rows)
       ()
-    } finally w.close()
-  }
+    }
 
   /** Opens a [[CsvWriter]] on the specified `S`.
     *

--- a/core/shared/src/main/scala/kantan/csv/CsvSink.scala
+++ b/core/shared/src/main/scala/kantan/csv/CsvSink.scala
@@ -41,8 +41,13 @@ trait CsvSink[-S] extends Serializable { self =>
     * @param conf
     *   CSV writing behaviour.
     */
-  def write[A: HeaderEncoder](s: S, rows: IterableOnce[A], conf: CsvConfiguration)(implicit e: WriterEngine): Unit =
-    writer(s, conf).write(rows).close()
+  def write[A: HeaderEncoder](s: S, rows: IterableOnce[A], conf: CsvConfiguration)(implicit e: WriterEngine): Unit = {
+    val w = writer(s, conf)
+    try {
+      w.write(rows)
+      ()
+    } finally w.close()
+  }
 
   /** Opens a [[CsvWriter]] on the specified `S`.
     *

--- a/core/shared/src/main/scala/kantan/csv/ops/CsvRowReadingOps.scala
+++ b/core/shared/src/main/scala/kantan/csv/ops/CsvRowReadingOps.scala
@@ -39,11 +39,13 @@ final class CsvRowReadingOps[A](private val a: A) extends AnyVal {
   def readCsvRow[B: RowDecoder](conf: CsvConfiguration)(implicit e: ReaderEngine, src: CsvSource[A]): ReadResult[B] = {
     val reader = a.asCsvReader[B](conf)
 
-    reader.next().flatMap { res =>
-      // Slight abuse of `no such element` to mean that we're not working with a single row.
-      if(reader.hasNext) ParseResult.noSuchElement
-      else ReadResult.success(res)
-    }
+    try
+      reader.next().flatMap { res =>
+        // Slight abuse of `no such element` to mean that we're not working with a single row.
+        if(reader.hasNext) ParseResult.noSuchElement
+        else ReadResult.success(res)
+      }
+    finally reader.close()
   }
 
   /** Parses a string as a single CSV row.

--- a/core/shared/src/main/scala/kantan/csv/ops/CsvRowReadingOps.scala
+++ b/core/shared/src/main/scala/kantan/csv/ops/CsvRowReadingOps.scala
@@ -22,6 +22,7 @@ import kantan.csv.ParseResult
 import kantan.csv.ReadResult
 import kantan.csv.RowDecoder
 import kantan.csv.engine.ReaderEngine
+import scala.util.Using
 
 /** Provides syntax for decoding a string as a CSV row. */
 final class CsvRowReadingOps[A](private val a: A) extends AnyVal {
@@ -36,17 +37,14 @@ final class CsvRowReadingOps[A](private val a: A) extends AnyVal {
     * res0: ReadResult[(Int, Int, Int)] = Right((1,2,3))
     *   }}}
     */
-  def readCsvRow[B: RowDecoder](conf: CsvConfiguration)(implicit e: ReaderEngine, src: CsvSource[A]): ReadResult[B] = {
-    val reader = a.asCsvReader[B](conf)
-
-    try
+  def readCsvRow[B: RowDecoder](conf: CsvConfiguration)(implicit e: ReaderEngine, src: CsvSource[A]): ReadResult[B] =
+    Using.resource(a.asCsvReader[B](conf)) { reader =>
       reader.next().flatMap { res =>
         // Slight abuse of `no such element` to mean that we're not working with a single row.
         if(reader.hasNext) ParseResult.noSuchElement
         else ReadResult.success(res)
       }
-    finally reader.close()
-  }
+    }
 
   /** Parses a string as a single CSV row.
     *

--- a/core/shared/src/test/scala/kantan/csv/ResourceLifecycleTests.scala
+++ b/core/shared/src/test/scala/kantan/csv/ResourceLifecycleTests.scala
@@ -49,6 +49,12 @@ class ResourceLifecycleTests extends AnyFunSuite with Matchers {
     }
   }
 
+  private final class ThrowingOnCloseWriter extends Writer {
+    override def write(cbuf: Array[Char], off: Int, len: Int): Unit = ()
+    override def flush(): Unit = ()
+    override def close(): Unit = throw new RuntimeException("close-failure")
+  }
+
   test("readCsvRow closes the underlying Reader on success") {
     val r = new TrackingReader("1,2,3")
     val _ = r.readCsvRow[(Int, Int, Int)](rfc)
@@ -90,6 +96,22 @@ class ResourceLifecycleTests extends AnyFunSuite with Matchers {
       CsvSink[TrackingWriter].write(w, List(Explode(1)), rfc)
     }
     w.closed.get should be(true)
+  }
+
+  test("CsvSink.write preserves the primary exception when close also throws") {
+    final case class Explode(x: Int)
+    implicit val explode: RowEncoder[Explode] =
+      RowEncoder.from(_ => throw new RuntimeException("write-failure"))
+
+    implicit val sink: CsvSink[ThrowingOnCloseWriter] =
+      CsvSink.from(identity)
+
+    val thrown = intercept[RuntimeException] {
+      CsvSink[ThrowingOnCloseWriter].write(new ThrowingOnCloseWriter, List(Explode(1)), rfc)
+    }
+
+    thrown.getMessage should be("write-failure")
+    thrown.getSuppressed.toList.map(_.getMessage) should contain("close-failure")
   }
 
   test("CsvReader.apply closes the Reader when the returned iterator is closed on the success path") {

--- a/core/shared/src/test/scala/kantan/csv/ResourceLifecycleTests.scala
+++ b/core/shared/src/test/scala/kantan/csv/ResourceLifecycleTests.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 Nicolas Rinaudo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kantan.csv
+
+import java.io.Reader
+import java.io.StringReader
+import java.io.Writer
+import java.util.concurrent.atomic.AtomicBoolean
+import kantan.csv.ops.*
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ResourceLifecycleTests extends AnyFunSuite with Matchers {
+
+  private final class TrackingReader(content: String) extends Reader {
+    private val underlying = new StringReader(content)
+    val closed = new AtomicBoolean(false)
+
+    override def read(cbuf: Array[Char], off: Int, len: Int): Int =
+      underlying.read(cbuf, off, len)
+
+    override def close(): Unit = {
+      closed.set(true)
+      underlying.close()
+    }
+  }
+
+  private final class TrackingWriter extends Writer {
+    val closed = new AtomicBoolean(false)
+    override def write(cbuf: Array[Char], off: Int, len: Int): Unit = ()
+    override def flush(): Unit = ()
+    override def close(): Unit = {
+      closed.set(true)
+      ()
+    }
+  }
+
+  test("readCsvRow closes the underlying Reader on success") {
+    val r = new TrackingReader("1,2,3")
+    val _ = r.readCsvRow[(Int, Int, Int)](rfc)
+    r.closed.get should be(true)
+  }
+
+  test("readCsvRow closes the underlying Reader when there are extra rows") {
+    val r = new TrackingReader("1,2,3\n4,5,6")
+    val _ = r.readCsvRow[(Int, Int, Int)](rfc)
+    r.closed.get should be(true)
+  }
+
+  test("readCsvRow closes the underlying Reader when decoding fails") {
+    val r = new TrackingReader("not-an-int,2,3")
+    val _ = r.readCsvRow[(Int, Int, Int)](rfc)
+    r.closed.get should be(true)
+  }
+
+  test("CsvSink.write closes the writer when a row encoder throws") {
+    final case class Explode(x: Int)
+    implicit val explode: RowEncoder[Explode] =
+      RowEncoder.from(_ => throw new RuntimeException("boom"))
+
+    implicit val sink: CsvSink[TrackingWriter] =
+      CsvSink.from(identity)
+
+    val w = new TrackingWriter
+
+    assertThrows[RuntimeException] {
+      CsvSink[TrackingWriter].write(w, List(Explode(1)), rfc)
+    }
+    w.closed.get should be(true)
+  }
+
+  test("CsvReader.apply closes the Reader when header decoding fails") {
+    final case class Row(a: Int, b: Int)
+    // The decoder expects headers "a" and "b"; the CSV provides "x" and "y".
+    implicit val hd: HeaderDecoder[Row] = HeaderDecoder.decoder("a", "b")(Row.apply)
+
+    val r = new TrackingReader("x,y\n1,2\n")
+    // `CsvReader.apply` must release the Reader as soon as header decoding fails, since the returned iterator no
+    // longer references it.
+    val _ = CsvReader[Row](r, rfc.withHeader)
+    r.closed.get should be(true)
+  }
+}

--- a/core/shared/src/test/scala/kantan/csv/ResourceLifecycleTests.scala
+++ b/core/shared/src/test/scala/kantan/csv/ResourceLifecycleTests.scala
@@ -67,6 +67,15 @@ class ResourceLifecycleTests extends AnyFunSuite with Matchers {
     r.closed.get should be(true)
   }
 
+  test("CsvSink.write closes the writer on the success path") {
+    implicit val sink: CsvSink[TrackingWriter] =
+      CsvSink.from(identity)
+
+    val w = new TrackingWriter
+    CsvSink[TrackingWriter].write(w, List(1, 2, 3), rfc)
+    w.closed.get should be(true)
+  }
+
   test("CsvSink.write closes the writer when a row encoder throws") {
     final case class Explode(x: Int)
     implicit val explode: RowEncoder[Explode] =
@@ -81,6 +90,16 @@ class ResourceLifecycleTests extends AnyFunSuite with Matchers {
       CsvSink[TrackingWriter].write(w, List(Explode(1)), rfc)
     }
     w.closed.get should be(true)
+  }
+
+  test("CsvReader.apply closes the Reader when the returned iterator is closed on the success path") {
+    final case class Row(a: Int, b: Int)
+    implicit val hd: HeaderDecoder[Row] = HeaderDecoder.decoder("a", "b")(Row.apply)
+
+    val r = new TrackingReader("a,b\n1,2\n3,4\n")
+    val reader = CsvReader[Row](r, rfc.withHeader)
+    reader.close()
+    r.closed.get should be(true)
   }
 
   test("CsvReader.apply closes the Reader when header decoding fails") {


### PR DESCRIPTION
## Summary

Three related resource-hygiene bugs in core:

1. **`CsvRowReadingOps.readCsvRow`** opened a `CsvReader` via `asCsvReader` and never closed it. For in-memory sources this was cheap, but for `File`/`URL` sources the file descriptor leaked every call. Fixed with `try/finally`.
2. **`CsvSink.write`** composed `writer(s, conf).write(rows).close()` as a single expression. If the caller's `RowEncoder` threw during `.write`, the trailing `.close()` was unreachable and the writer leaked. Fixed with `try/finally`.
3. **`CsvReader.apply`** produced `data` via `ReaderEngine.readerFor` (which attaches `reader.close()` as the release handler). On header-decode failure, the returned iterator was rebuilt via `ResourceIterator(ReadResult.failure(error))`, silently dropping `data`'s close handle — the underlying `Reader` leaked. Fixed by closing `data` eagerly when header decoding fails, since the returned iterator no longer references it. `close()` is idempotent on `ResourceIterator`, so subsequent user-initiated close calls remain safe.

New JVM tests in `ResourceLifecycleTests` cover each path with a `TrackingReader`/`TrackingWriter` that records close invocations.

## Test plan

- [x] `coreJVM2_13/testOnly kantan.csv.ResourceLifecycleTests` — 5/5 green (3 originally failing)
- [x] `coreJVM2_13/test` — 2460/2460 green
- [x] `coreJVM3/test` — 2877/2877 green
- [x] `scalafmtAll`